### PR TITLE
Docs/workspace and script keyword

### DIFF
--- a/content/reference/globals/script.md
+++ b/content/reference/globals/script.md
@@ -1,6 +1,14 @@
 ---
 title: script
-description: Stub
+description: Keyword representing the current script instance
 ---
 
-Stub
+<!-- 
+script
+Revision 1
+
+Written by mezz-source on August 29th, 2026
+-->
+
+The `script` keyword can be used to access the instance of the current script.
+It can be used to index nearby instances or change the properties relating to itself.

--- a/content/reference/globals/script.md
+++ b/content/reference/globals/script.md
@@ -12,3 +12,8 @@ Written by mezz-source on August 29th, 2026
 
 The `script` keyword can be used to access the instance of the current script.
 It can be used to index nearby instances or change the properties relating to itself.
+
+
+<!--
+stub until scripting releases
+-->

--- a/content/reference/globals/workspace.md
+++ b/content/reference/globals/workspace.md
@@ -18,6 +18,7 @@ It can be used to index specific instances or to collect objects quickly, in res
 > Instances may be unavailable when loading. Make sure instances exist before accessing.
 > Failure to do so may result in runtime errors.
 
+
 <!--
 stub until scripting releases
 -->

--- a/content/reference/globals/workspace.md
+++ b/content/reference/globals/workspace.md
@@ -1,6 +1,23 @@
 ---
 title: workspace
-description: Stub
+description: Keyword representing the global Workspace root
 ---
 
-Stub
+<!-- 
+workspace
+Revision 1
+
+Written by mezz-source on August 29th, 2026
+-->
+
+The `workspace` keyword represents game's root `Workspace` container, which contains all physical models, parts, and other instances that can exist inside of it.
+
+It can be used to index specific instances or to collect objects quickly, in respect to the server or client's current understanding.
+
+> [!WARNING]
+> Instances may be unavailable when loading. Make sure instances exist before accessing.
+> Failure to do so may result in runtime errors.
+
+<!--
+stub until scripting releases
+-->


### PR DESCRIPTION
Added brief explanations for `script` & `workspace`, along with updating their title and descriptions to reflect their intent for scripting.
Waiting for release to provide example blocks!