### PR TITLE
Update tween-info.md

### DIFF
--- a/content/reference/datatypes/tween-info.md
+++ b/content/reference/datatypes/tween-info.md
@@ -1,6 +1,69 @@
 ---
 title: TweenInfo
-description: Stub
+description: Information of a tween
 ---
 
-Stub
+## Summary
+
+<details>
+<summary><b>Properties</b></summary>
+Properties of a `TweenInfo`.
+<br><br>
+
+
+* [Time](#time): `Number`
+* [EasingStyle](https://create.playvortex.io/reference/globals/enum/#easingstyle): `Enum`
+* [EasingDirection](https://create.playvortex.io/reference/globals/enum/#easingdirection): `Enum`
+* [RepeatCount](#repeatcount): `Number`
+* [Reverses](#reverses): `Boolean`
+* [DelayTime](#delaytime): `Number`
+
+</details>
+
+## Properties
+
+### Time
+
+> `Number`
+>
+> Duration for the tween, in seconds.
+
+<br/>
+
+### EasingStyle
+
+> `Enum.EasingStyle`
+>
+> Easing style for the tween.
+
+<br/> 
+
+### EasingDirection 
+
+> `Enum.EasingDirection`
+>
+> Direction in which the tween should execute.
+<br/>
+
+### RepeatCount
+
+> `Number`
+>
+> Number of times the tween repeats.
+
+<br/>
+
+### Reverses 
+
+> `Boolean`
+>
+> Whether the tween should reverse to the starting value once it reaches its target.
+
+<br/>
+
+### DelayTime 
+
+> `Number`
+>
+> Time before the tween begins, in seconds.
+<br/>


### PR DESCRIPTION
Expands the stub of tween-info datatype.

Both enums link to the Enum page's relevant header, assuming they will be there eventually.