### PR TITLE
Use relative paths because absolute paths aren't working on website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,7 @@ For larger changes, open an issue first so we can discuss them.
 - Keep code blocks copy/paste-friendly (show full commands).
 - When adding CLI examples, include the expected output where helpful.
 - Avoid project-specific assumptions; where necessary, document environmental details (OS, versions).
+- All paths must be relative.
 
 ## File structure and assets
 
@@ -88,5 +89,6 @@ Before requesting review, ensure:
 - Links and images render correctly.
 - Any necessary screenshots or examples are included.
 - If the change affects a live site, the preview/build has been tested locally.
+- Ensure all paths are relative.
 ------------------------------------------------------------
 Thanks for taking the time to contribute to Vortex Docs!

--- a/content/guides/intro.md
+++ b/content/guides/intro.md
@@ -18,4 +18,4 @@ Vortex Engine provides APIs for building your game, creating parts, writing scri
 
 This documentation will introduce you to the scripting API, and the features provided by Vortex Engine.
 
-If you're new to Vortex Studio, you may want to start with [Your First Script guide](/content/guides/first-script.md).
+If you're new to Vortex Studio, you may want to start with [Your First Script guide](./first-script.md).

--- a/content/reference/classes/lighting.md
+++ b/content/reference/classes/lighting.md
@@ -27,9 +27,9 @@ Properties of Lighting, in the order they appear on Vortex Studio.
 <details>
 <summary><b>Appearance</b></summary>
 
-- [Ambient Color](#ambient-color): [`Color3`](/content/reference/datatypes/color3.md)
+- [Ambient Color](#ambient-color): [`Color3`](../datatypes/color3.md)
 - [Brightness](#brightness): `Float`
-- [Sun Color](#sun-color): [`Color3`](/content/reference/datatypes/color3.md)
+- [Sun Color](#sun-color): [`Color3`](../datatypes/color3.md)
 - [Sun Brightness](#sun-brightness): `Float`
 - [Sun Shadows](#sun-shadows): `Boolean`
 
@@ -38,9 +38,9 @@ Properties of Lighting, in the order they appear on Vortex Studio.
 <details>
 <summary><b>Transform</b></summary>
 
-- [Position](#position): [`Vector3`](/content/reference/datatypes/vector3.md)
-- [Rotation](#rotation): [`Vector3`](/content/reference/datatypes/vector3.md)
-- [Size](#size): [`Vector3`](/content/reference/datatypes/vector3.md)
+- [Position](#position): [`Vector3`](../datatypes/vector3.md)
+- [Rotation](#rotation): [`Vector3`](../datatypes/vector3.md)
+- [Size](#size): [`Vector3`](../datatypes/vector3.md)
 
 </details>
 
@@ -51,7 +51,7 @@ Properties of Lighting, in the order they appear on Vortex Studio.
 ## Properties
 
 ### Ambient Color
-> [`Color3`](/content/reference/datatypes/color3.md) \
+> [`Color3`](../datatypes/color3.md) \
 \
 Determines the visible color of the `part`.
 Will also affect the part's [`Material`]() color.
@@ -67,7 +67,7 @@ Determines how bright the `ambient` lighting is.
 
 
 ### Position
-> [`Vector3`](/content/reference/datatypes/vector3.md) \
+> [`Vector3`](../datatypes/vector3.md) \
 \
 This value has `no effect`.
 
@@ -75,7 +75,7 @@ This value has `no effect`.
 
 
 ### Rotation
-> [`Vector3`](/content/reference/datatypes/vector3.md) \
+> [`Vector3`](../datatypes/vector3.md) \
 \
 Determines the angle at which sunlight hits objects, and as such the dimensions of shadows.
 
@@ -83,7 +83,7 @@ Determines the angle at which sunlight hits objects, and as such the dimensions 
 
 
 ### Size
-> [`Vector3`](/content/reference/datatypes/vector3.md) \
+> [`Vector3`](../datatypes/vector3.md) \
 \
 This value is `read-only` has `no effect`.
 
@@ -97,7 +97,7 @@ Determines how bright the `sun` lighting is.
 <br/>
 
 ### Sun Color
-> [`Color3`](/content/reference/datatypes/color3.md) \
+> [`Color3`](../datatypes/color3.md) \
 \
 Determines the color of sunlight that hits objects.
 Will blend with the ambient coloring.

--- a/content/reference/classes/model.md
+++ b/content/reference/classes/model.md
@@ -11,7 +11,7 @@ Written by KingTasaz on August 28th, 2026
 -->
 
 ## Summary
-Models are a very simple way to group [`parts`](/content/reference/classes/part.md) together.
+Models are a very simple way to group [`parts`](./part.md) together.
 Creating a model requires at least `2` parts selected, but otherwise the second part can be deleted. Parts in a model are not truly connected, but only grouped in the explorer. Models currently have no purpose other than organization.
 
 A model with no children is still shown in the explorer, but does not exist in the world and has no transform controls.
@@ -28,7 +28,7 @@ Properties of a Model, in the order they appear on Vortex Studio.
 <summary><b>Transform</b></summary>
 
 - [Name](#name): `String`
-- [Position](#position): [`Vector3`](/content/reference/datatypes/vector3.md)
+- [Position](#position): [`Vector3`](../datatypes/vector3.md)
 
 </details>
 
@@ -47,7 +47,7 @@ The name of the `model`, and its label in the explorer.
 
 
 ### Position
-> [`Vector3`](/content/reference/datatypes/vector3.md) \
+> [`Vector3`](../datatypes/vector3.md) \
 \
 The position of the `model`, in World-space.
 A model's position is automatically set to the mathematical average of all its children's positions. (See [Images](#images))

--- a/content/reference/classes/part.md
+++ b/content/reference/classes/part.md
@@ -20,9 +20,9 @@ Properties of a Part, in the order they appear on Vortex Studio.
 <details>
 <summary><b>Appearance</b></summary>
 
-- [Color](#color): [`Color3`](/content/reference/datatypes/color3.md)
+- [Color](#color): [`Color3`](../datatypes/color3.md)
 - [Transparency](#transparency): `Float`
-- [Material](#material): [`Enum.Material`](/content/reference/datatypes/enumitem.md) <!-- not sure if this should link to enumitem.md or enum.md -->
+- [Material](#material): [`Enum.Material`](../datatypes/enumitem.md) <!-- not sure if this should link to enumitem.md or enum.md -->
 - [Cast Shadow](#cast-shadow): `Boolean`
 
 </details>
@@ -40,9 +40,9 @@ Properties of a Part, in the order they appear on Vortex Studio.
 <summary><b>Transform</b></summary>
 
 - [Name](#name): `String`
-- [Position](#position): [`Vector3`](/content/reference/datatypes/vector3.md)
-- [Rotation](#rotation): [`Vector3`](/content/reference/datatypes/vector3.md)
-- [Size](#size): [`Vector3`](/content/reference/datatypes/vector3.md)
+- [Position](#position): [`Vector3`](../datatypes/vector3.md)
+- [Rotation](#rotation): [`Vector3`](../datatypes/vector3.md)
+- [Size](#size): [`Vector3`](../datatypes/vector3.md)
 
 </details>
 
@@ -103,7 +103,7 @@ This can be used to save performance with part's whose shadows cannot be seen, o
 
 
 ### Color
-> [`Color3`](/content/reference/datatypes/color3.md) \
+> [`Color3`](../datatypes/color3.md) \
 \
 Determines the visible color of the `part`.
 Will also affect the part's [`Material`]() color.
@@ -112,7 +112,7 @@ Will also affect the part's [`Material`]() color.
 
 
 ### Material
-> [`Enum.Material`](/content/reference/datatypes/enumitem.md) \
+> [`Enum.Material`](../datatypes/enumitem.md) \
 \
 Determines which `Material` type to apply when rendering the `part`.
 Currently this has no effect other than visual.
@@ -129,7 +129,7 @@ The name of the `part`, and its label in the explorer.
 
 
 ### Position
-> [`Vector3`](/content/reference/datatypes/vector3.md) \
+> [`Vector3`](../datatypes/vector3.md) \
 \
 The position of the `part`, in World-space.
 
@@ -137,7 +137,7 @@ The position of the `part`, in World-space.
 
 
 ### Rotation
-> [`Vector3`](/content/reference/datatypes/vector3.md) \
+> [`Vector3`](../datatypes/vector3.md) \
 \
 The rotation of the `part` along each axis.
 
@@ -145,7 +145,7 @@ The rotation of the `part` along each axis.
 
 
 ### Size
-> [`Vector3`](/content/reference/datatypes/vector3.md) \
+> [`Vector3`](../datatypes/vector3.md) \
 \
 The size of the `part` in each dimension (width, height, depth).
 

--- a/content/reference/classes/point-light.md
+++ b/content/reference/classes/point-light.md
@@ -11,7 +11,7 @@ Written by KingTasaz on August 28th, 2026
 -->
 
 ## Summary
-A `pointlight` must be the child of a [`part`](/content/reference/classes/part.md), and takes the position of its parent as its own.
+A `pointlight` must be the child of a [`part`](../classes/part.md), and takes the position of its parent as its own.
 
 There is currently no on/off switch for lights, but setting either the color, brightness, or range to 0 will have the desired effect.
 
@@ -23,7 +23,7 @@ Properties of a Pointlight, in the order they appear on Vortex Studio.
 <details>
 <summary><b>Appearance</b></summary>
 
-- [Color](#color): [`Color3`](/content/reference/datatypes/color3.md)
+- [Color](#color): [`Color3`](../datatypes/color3.md)
 - [Brightness](#brightness): `Float`
 - [Range](#range): `Float`
 
@@ -49,7 +49,7 @@ The emission brightness of the light. Does not affect range.
 <br/>
 
 ### Color
-> [`Color3`](/content/reference/datatypes/color3.md) \
+> [`Color3`](../datatypes/color3.md) \
 \
 Determines the color of the emitted light.
 Darker colors have the same effect as turning off the light.

--- a/content/reference/classes/spawnlocation.md
+++ b/content/reference/classes/spawnlocation.md
@@ -22,9 +22,9 @@ Properties of a SpawnLocation, in the order they appear on Vortex Studio.
 <details>
 <summary><b>Appearance</b></summary>
 
-- [Color](./part.md#color): [`Color3`](/content/reference/datatypes/color3.md)
+- [Color](./part.md#color): [`Color3`](../datatypes/color3.md)
 - [Transparency](./part.md#transparency): `Float`
-- [Material](./part.md#material): [`Enum.Material`](/content/reference/datatypes/enumitem.md) <!-- not sure if this should link to enumitem.md or enum.md -->
+- [Material](./part.md#material): [`Enum.Material`](../datatypes/enumitem.md) <!-- not sure if this should link to enumitem.md or enum.md -->
 - [Cast Shadow](./part.md#cast-shadow): `Boolean`
 
 </details>
@@ -42,9 +42,9 @@ Properties of a SpawnLocation, in the order they appear on Vortex Studio.
 <summary><b>Transform</b></summary>
 
 - [Name](./part.md#name): `String`
-- [Position](./part.md#position): [`Vector3`](/content/reference/datatypes/vector3.md)
-- [Rotation](./part.md#rotation): [`Vector3`](/content/reference/datatypes/vector3.md)
-- [Size](./part.md#size): [`Vector3`](/content/reference/datatypes/vector3.md)
+- [Position](./part.md#position): [`Vector3`](../datatypes/vector3.md)
+- [Rotation](./part.md#rotation): [`Vector3`](../datatypes/vector3.md)
+- [Size](./part.md#size): [`Vector3`](../datatypes/vector3.md)
 
 </details>
 

--- a/content/reference/classes/spot-light.md
+++ b/content/reference/classes/spot-light.md
@@ -11,7 +11,7 @@ Written by KingTasaz on August 28th, 2026
 -->
 
 ## Summary
-A `spotlight` must be the child of a [`part`](/content/reference/classes/part.md), and takes the position of its parent as its own.
+A `spotlight` must be the child of a [`part`](./part.md), and takes the position of its parent as its own.
 
 There is currently no on/off switch for lights, but setting either the color, brightness, angle, or range to 0 will have the desired effect.
 
@@ -25,11 +25,11 @@ Properties of a SpotLight, in the order they appear on Vortex Studio.
 <details>
 <summary><b>Appearance</b></summary>
 
-- [Color](#color): [`Color3`](/content/reference/datatypes/color3.md)
+- [Color](#color): [`Color3`](../datatypes/color3.md)
 - [Brightness](#brightness): `Float`
 - [Range](#range): `Float`
 - [Angle](#angle): `Float`
-- [Face](#face): [`Enum.Face`](/content/reference/datatypes/enumitem.md)
+- [Face](#face): [`Enum.Face`](../datatypes/enumitem.md)
 
 </details>
 
@@ -61,7 +61,7 @@ The emission brightness of the light. Does not affect range.
 <br/>
 
 ### Color
-> [`Color3`](/content/reference/datatypes/color3.md) \
+> [`Color3`](../datatypes/color3.md) \
 \
 Determines the color of the emitted light.
 Darker colors have the same effect as turning off the light.
@@ -70,9 +70,9 @@ Darker colors have the same effect as turning off the light.
 
 
 ### Face
-> [`Enum.Face`](/content/reference/datatypes/enumitem.md) \
+> [`Enum.Face`](../datatypes/enumitem.md) \
 \
-Controls which face of the parent [`part`](/content/reference/classes/part.md) that the light is emitted from.
+Controls which face of the parent [`part`](./part.md) that the light is emitted from.
 
 <br/>
 

--- a/content/reference/classes/texture.md
+++ b/content/reference/classes/texture.md
@@ -11,7 +11,7 @@ Written by KingTasaz on August 28th, 2026
 -->
 
 ## Summary
-When a texture is added to a [`part`](/content/reference/classes/part.md), its `Face` and `name` get set automatically, so adding 6 textures to cover an entire part is very quick.
+When a texture is added to a [`part`](./part.md), its `Face` and `name` get set automatically, so adding 6 textures to cover an entire part is very quick.
 <br><br>
 
 <details>
@@ -22,8 +22,8 @@ Properties of a Texture, in the order they appear on Vortex Studio.
 <details>
 <summary><b>Texture</b></summary>
 
-- [Face](#face): [`Enum.Face`](/content/reference/datatypes/enumitem.md)
-- [Texture](#texture): [`Enum.Texture`](/content/reference/datatypes/enumitem.md)
+- [Face](#face): [`Enum.Face`](../datatypes/enumitem.md)
+- [Texture](#texture): [`Enum.Texture`](../datatypes/enumitem.md)
 
 </details>
 
@@ -34,14 +34,14 @@ Properties of a Texture, in the order they appear on Vortex Studio.
 ## Properties
 
 ### Face
-> [`Enum.Face`](/content/reference/datatypes/enumitem.md) \
+> [`Enum.Face`](../datatypes/enumitem.md) \
 \
-Controls which face of the parent [`part`](/content/reference/classes/part.md) that the texture is displayed on.
+Controls which face of the parent [`part`](./part.md) that the texture is displayed on.
 
 <br/>
 
 ### Texture
-> [`Enum.Texture`](/content/reference/datatypes/enumitem.md) \
+> [`Enum.Texture`](../datatypes/enumitem.md) \
 \
 Sets which texture to render onto the selected face.
 Currently the only options are `Inlets` or `Studs`. 

--- a/content/reference/datatypes/signal.md
+++ b/content/reference/datatypes/signal.md
@@ -23,14 +23,14 @@ Written by TheJustDare on August 30th, 2026
 
 ## Overview
 
-[Signal](/content/reference/datatypes/signal.md) is a data type that is used in user-defined functions, otherwise known as **listeners**, to trigger when something happens in the game. \
- The [Signal](/content/reference/datatypes/signal.md) might also happen to pass arguments to each listener depending on which event it is.
+[Signal](./signal.md) is a data type that is used in user-defined functions, otherwise known as **listeners**, to trigger when something happens in the game. \
+ The [Signal](./signal.md) might also happen to pass arguments to each listener depending on which event it is.
 
  ## Methods
 
  ### Connect()
 
- Connects the given function and creates a new [Connection](/content/reference/datatypes/connection.md).
+ Connects the given function and creates a new [Connection](./connection.md).
 
  ```lua
 local part = workspace.Part
@@ -53,7 +53,7 @@ Unlike [Connect](#connect), `ConnectParallel` runs the connected function on a d
 
 ### Once()
 
-Connects the given function and creates a new [Connection](/content/reference/datatypes/connection.md). \
+Connects the given function and creates a new [Connection](./connection.md). \
 `Once` will run the function only **once**, unlike the other methods.
 
 ```lua

--- a/content/reference/globals/game.md
+++ b/content/reference/globals/game.md
@@ -37,12 +37,12 @@ Methods of `game`.
 Services of `game`.
 <br><br>
 
-* [Workspace](/content/reference/classes/workspace.md)
-* [Players](/content/reference/classes/players.md)
-* [ReplicatedStorage](/content/reference/classes/replicated-storage.md)
-* [StarterPlayerScripts](/content/reference/classes/starter-player-scripts.md)
-* [ServerScriptService](/content/reference/classes/server-script-service.md)
-* [Lighting](/content/reference/classes/lighting.md)
+* [Workspace](../classes/workspace.md)
+* [Players](../classes/players.md)
+* [ReplicatedStorage](../classes/replicated-storage.md)
+* [StarterPlayerScripts](../classes/starter-player-scripts.md)
+* [ServerScriptService](../classes/server-script-service.md)
+* [Lighting](../classes/lighting.md)
 
 </details>
 
@@ -62,7 +62,7 @@ Services of `game`.
 
 > `Instance`
 > 
-> The Workspace is the root object that holds anything that is currently in the world. [Workspace](/content/reference/classes/workspace.md)
+> The Workspace is the root object that holds anything that is currently in the world. [Workspace](../classes/workspace.md)
 
 <br/>
 
@@ -70,7 +70,7 @@ Services of `game`.
 
 > `Instance`
 >
-> Stub. [Players](/content/reference/classes/players.md)
+> Stub. [Players](../classes/players.md)
 
 <br/>
 
@@ -78,7 +78,7 @@ Services of `game`.
 
 > `Instance`
 >
-> ReplicatedStorage contains objects replicated to the Client and Server. When the Server makes a modification, this is replicated to all clients. Any changes made by clients are not replicated to the server. [ReplicatedStorage](/content/reference/classes/replicated-storage.md)
+> ReplicatedStorage contains objects replicated to the Client and Server. When the Server makes a modification, this is replicated to all clients. Any changes made by clients are not replicated to the server. [ReplicatedStorage](../classes/replicated-storage.md)
 
 <br/>
 
@@ -86,7 +86,7 @@ Services of `game`.
 
 > `Instance`
 >
-> Stub. [StarterPlayerScripts](/content/reference/classes/starter-player-scripts.md)
+> Stub. [StarterPlayerScripts](../classes/starter-player-scripts.md)
 
 <br/>
 
@@ -94,7 +94,7 @@ Services of `game`.
 
 > `Instance`
 >
-> ServerScriptService contains [Scripts](/content/reference/classes/script.md) that run when the server starts. [ServerScriptService](/content/reference/classes/server-script-service.md)
+> ServerScriptService contains [Scripts](../classes/script.md) that run when the server starts. [ServerScriptService](../classes/server-script-service.md)
 
 <br/>
 
@@ -102,6 +102,6 @@ Services of `game`.
 
 > `Instance`
 >
-> Lighting is the game service that controls basic rendering and atmospherics. [Lighting](/content/reference/classes/lighting.md)
+> Lighting is the game service that controls basic rendering and atmospherics. [Lighting](../classes/lighting.md)
 
 <br/>

--- a/content/reference/globals/instance-new.md
+++ b/content/reference/globals/instance-new.md
@@ -21,7 +21,7 @@ Written by Arbuzyonak on August 30th, 2026
 
 ## Overview
 
-`Instance.new` creates a new [`Instance`](/content/reference/classes/instance.md) of the class passed as `className`.
+`Instance.new` creates a new [`Instance`](../classes/instance.md) of the class passed as `className`.
 
 ```lua
 local part = Instance.new("Part")
@@ -32,7 +32,7 @@ print(part.Name)       --> Part
 
 ## Parenting
 
-A new instance has no parent: it exists in memory, but it is not rendered, replicated, or saved until you assign its [`Parent`](/content/reference/classes/instance.md).
+A new instance has no parent: it exists in memory, but it is not rendered, replicated, or saved until you assign its [`Parent`](../classes/instance.md).
 
 Set the parent **last**, after configuring the instance, so scripts listening for new objects receive it fully configured:
 
@@ -62,6 +62,6 @@ If no parent is passed in, nor set later, the Instance's parent defaults to **wo
 
 ## Notes
 
-- Common creatable classes include [`Part`](/content/reference/classes/part.md), [`Model`](/content/reference/classes/model.md), [`Folder`](/content/reference/classes/folder.md), [`SpawnLocation`](/content/reference/classes/spawnlocation.md), [`Script`](/content/reference/classes/script.md), [`LocalScript`](/content/reference/classes/localscript.md), [`ModuleScript`](/content/reference/classes/modulescript.md), [`IntValue`](/content/reference/classes/int-value.md), [`StringValue`](/content/reference/classes/string-value.md), [`BindableEvent`](/content/reference/classes/bindable-event.md), [`RemoteEvent`](/content/reference/classes/remote-event.md), [`RemoteFunction`](/content/reference/classes/remote-function.md), [`PointLight`](/content/reference/classes/point-light.md), and [`SpotLight`](/content/reference/classes/spot-light.md).
+- Common creatable classes include [`Part`](../classes/part.md), [`Model`](../classes/model.md), [`Folder`](../classes/folder.md), [`SpawnLocation`](../classes/spawnlocation.md), [`Script`](../classes/script.md), [`LocalScript`](../classes/localscript.md), [`ModuleScript`](../classes/modulescript.md), [`IntValue`](../classes/int-value.md), [`StringValue`](../classes/string-value.md), [`BindableEvent`](../classes/bindable-event.md), [`RemoteEvent`](../classes/remote-event.md), [`RemoteFunction`](../classes/remote-function.md), [`PointLight`](../classes/point-light.md), and [`SpotLight`](../classes/spot-light.md).
 
 <br/>


### PR DESCRIPTION
Use relative paths because absolute paths aren't working on website. absolute paths aren't working because absolute paths go "content" instead of direct, Like
absolute paths go https://create.playvortex.io/content/guides/first-script.md (this link is not working)
instead of https://create.playvortex.io/guides/first-script.md (but this is working)