### PR TITLE
docs: document object-specific Instance APIs

### DIFF
--- a/content/guides/instances.md
+++ b/content/guides/instances.md
@@ -9,8 +9,7 @@ Written by ElectroTato on the 30th of August, 2026
 
 # Summary
 
-`Instances` are the basic building blocks for objects in a game. Each concrete class has its own [`Properties`](https://create.playvortex.io/guides/properties/)
-and methods.
+`Instances` are the basic building blocks for objects in a game. Each concrete class has its own [`Properties`](https://create.playvortex.io/guides/properties/) and methods.
 
 You can create a new `Instance` using the [`Instance.new`](https://create.playvortex.io/reference/globals/instance-new/) method in a script, by passing in the `ClassName` of the `Instance` as the first argument.
 

--- a/content/guides/instances.md
+++ b/content/guides/instances.md
@@ -12,3 +12,9 @@ Written by ElectroTato on the 30th of August, 2026
 `Instances` are like the basic building blocks for every object in your game, there are several types of `Instances`, each having different [`Properties`](https://create.playvortex.io/guides/properties/) and unique quirks!
 
 You can create a new `Instance` using the [`Instance.new`](https://create.playvortex.io/reference/globals/instance-new/) method in a script, by passing in the `ClassName` of the `Instance` as the first argument.
+
+## Inspecting members
+
+Some engine-backed objects, including the Character projection, expose properties and methods through metatable lookup. Because of this, iterating over an object with `pairs()` does not list its complete API. Use the class reference to find supported members instead.
+
+The tested Vortex Studio 0.3.4 Character projection does not expose the Roblox `GetFullName()` or `FindFirstChildWhichIsA()` methods.

--- a/content/guides/instances.md
+++ b/content/guides/instances.md
@@ -9,12 +9,28 @@ Written by ElectroTato on the 30th of August, 2026
 
 # Summary
 
-`Instances` are like the basic building blocks for every object in your game, there are several types of `Instances`, each having different [`Properties`](https://create.playvortex.io/guides/properties/) and unique quirks!
+`Instances` are the basic building blocks for objects in a game. Each concrete
+class has its own [`Properties`](https://create.playvortex.io/guides/properties/)
+and method surface.
 
 You can create a new `Instance` using the [`Instance.new`](https://create.playvortex.io/reference/globals/instance-new/) method in a script, by passing in the `ClassName` of the `Instance` as the first argument.
 
+Vortex does not currently expose one universal base API on every engine-backed
+value. For example, `Part` exposes common hierarchy methods while `Player` and
+`Humanoid` do not. Check the concrete class reference before using a method.
+The [Instance reference](../reference/classes/instance.md) contains the tested
+Vortex Studio 0.3.4 availability matrix.
+
 ## Inspecting members
 
-Some engine-backed objects, including the Character projection, expose properties and methods through metatable lookup. Because of this, iterating over an object with `pairs()` does not list its complete API. Use the class reference to find supported members instead.
+Some engine-backed objects, including the Character projection, expose
+properties and methods through metatable lookup. Because of this, iterating
+over an object with `pairs()` does not list its complete API. For example,
+ordinary Part properties remain readable even when the iteration only reports
+method keys. Conversely, direct keys with internal-looking names are not
+evidence of a supported public API. Use the class reference to find supported
+members instead.
 
-The tested Vortex Studio 0.3.4 Character projection does not expose the Roblox `GetFullName()` or `FindFirstChildWhichIsA()` methods.
+The tested Vortex Studio 0.3.4 Character projection does not expose the Roblox
+`GetFullName()` or `FindFirstChildWhichIsA()` methods. Use
+`FindFirstChildOfClass()` where it fits the lookup.

--- a/content/guides/instances.md
+++ b/content/guides/instances.md
@@ -9,28 +9,11 @@ Written by ElectroTato on the 30th of August, 2026
 
 # Summary
 
-`Instances` are the basic building blocks for objects in a game. Each concrete
-class has its own [`Properties`](https://create.playvortex.io/guides/properties/)
-and method surface.
+`Instances` are the basic building blocks for objects in a game. Each concrete class has its own [`Properties`](https://create.playvortex.io/guides/properties/)
+and methods.
 
 You can create a new `Instance` using the [`Instance.new`](https://create.playvortex.io/reference/globals/instance-new/) method in a script, by passing in the `ClassName` of the `Instance` as the first argument.
 
-Vortex does not currently expose one universal base API on every engine-backed
-value. For example, `Part` exposes common hierarchy methods while `Player` and
-`Humanoid` do not. Check the concrete class reference before using a method.
-The [Instance reference](../reference/classes/instance.md) contains the tested
+Vortex does not currently expose one universal base API on every engine-backed value. For example, `Part` exposes common hierarchy methods while `Player` and
+`Humanoid` do not. Check the concrete class reference before using a method. The [Instance reference](../reference/classes/instance.md) contains the tested
 Vortex Studio 0.3.4 availability matrix.
-
-## Inspecting members
-
-Some engine-backed objects, including the Character projection, expose
-properties and methods through metatable lookup. Because of this, iterating
-over an object with `pairs()` does not list its complete API. For example,
-ordinary Part properties remain readable even when the iteration only reports
-method keys. Conversely, direct keys with internal-looking names are not
-evidence of a supported public API. Use the class reference to find supported
-members instead.
-
-The tested Vortex Studio 0.3.4 Character projection does not expose the Roblox
-`GetFullName()` or `FindFirstChildWhichIsA()` methods. Use
-`FindFirstChildOfClass()` where it fits the lookup.

--- a/content/guides/scripts-and-vms.md
+++ b/content/guides/scripts-and-vms.md
@@ -25,6 +25,22 @@ part.Parent = game.Workspace
 * `LocalScript`
 * `Script`
 
+### Script placement
+
+An editor-authored `Script` placed directly under a `Part` in `Workspace` ran
+during a Vortex Studio 0.3.4 playtest. Inside that script, `script.Parent`
+resolved to the containing Part:
+
+```lua
+local part = script.Parent
+print(part.Name, part.ClassName)
+```
+
+This confirms that a server Script does not have to be a direct child of
+`ServerScriptService` to execute. Runtime-created Script instances are a
+different case: their `Source` is not settable, so creating and parenting one
+does not create executable code.
+
 ### Luau Virtual Machine
 
 > The Luau Virtual Machine (VM) is responsible for executing compiled Luau code at runtime.

--- a/content/guides/scripts-and-vms.md
+++ b/content/guides/scripts-and-vms.md
@@ -25,22 +25,6 @@ part.Parent = game.Workspace
 * `LocalScript`
 * `Script`
 
-### Script placement
-
-An editor-authored `Script` placed directly under a `Part` in `Workspace` ran
-during a Vortex Studio 0.3.4 playtest. Inside that script, `script.Parent`
-resolved to the containing Part:
-
-```lua
-local part = script.Parent
-print(part.Name, part.ClassName)
-```
-
-This confirms that a server Script does not have to be a direct child of
-`ServerScriptService` to execute. Runtime-created Script instances are a
-different case: their `Source` is not settable, so creating and parenting one
-does not create executable code.
-
 ### Luau Virtual Machine
 
 > The Luau Virtual Machine (VM) is responsible for executing compiled Luau code at runtime.

--- a/content/reference/classes/instance.md
+++ b/content/reference/classes/instance.md
@@ -83,11 +83,9 @@ Common methods of an `Instance`-like object.
 
 <br/>
 
-## Vortex Studio 0.3.4 method availability
+## Vortex Studio Method Availability
 
-The following matrix records whether each member was exposed as a function on
-the live object. It verifies availability, not every edge case of the method's
-behavior.
+The following matrix records whether each member is exposed as a function on the live object.
 
 | Runtime object | `FindFirstChild` | `FindFirstChildOfClass` | `WaitForChild` | `GetChildren` | `GetDescendants` | `Clone` | `Destroy` | `IsA` |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -100,18 +98,6 @@ behavior.
 | [`Player`](./player.md) | No | No | No | No | No | No | No | No |
 | [`Humanoid`](./humanoid.md) | No | No | No | No | No | No | No | No |
 
-This is why Roblox inheritance alone is not enough to determine the available
-Vortex API. A `Players` service can still provide its class-specific
-`GetPlayers()` method, and a `Humanoid` can provide `IsDead()`, even though the
-tested generic methods above are absent.
+A `Players` service can still provide its class-specific `GetPlayers()` method, and a `Humanoid` can provide `IsDead()`, even though the generic methods above are absent.
 
-## Introspection limitation
-
-Engine-backed members may be provided through metatable lookup. `pairs()` only
-enumerates direct table keys, so it can omit readable properties and other
-supported members. It can also reveal engine-owned keys that are not public
-API. Do not use `pairs()` as a capability check; test the named member and
-consult the concrete class reference.
-
-These observations were made in Vortex Studio 0.3.4 and may change in later
-versions.
+These observations were made in Vortex Studio 0.3.4 and may change in later versions.

--- a/content/reference/classes/instance.md
+++ b/content/reference/classes/instance.md
@@ -1,6 +1,6 @@
 ---
 title: Instance
-description: Instance is the base class for all classes in Vortex engine
+description: Shared conventions for engine-backed objects in Vortex.
 ---
 
 <!-- 
@@ -10,14 +10,17 @@ Revision 1
 Written by Kindtracker on August 28th, 2026
 -->
 
-> [!NOTE] 
-> There will be more things (methods, constructors, properties, etc) in the future. This is based on leaks and common sense.
+> [!IMPORTANT]
+> Vortex Studio 0.3.4 does not expose one uniform Instance method set on every
+> engine-backed value. The members below describe ordinary Instance-like
+> objects. Use the concrete class reference and the availability matrix on this
+> page before calling a method.
 
 ## Summary
 
 <details>
 <summary><b>Properties</b></summary>
-Properties of a `Instance`.
+Common properties of an `Instance`-like object.
 <br><br>
 
 * [Name](#name): `String`
@@ -27,7 +30,7 @@ Properties of a `Instance`.
 
 <details>
 <summary><b>Methods</b></summary>
-Methods of a `Instance`.
+Common methods of an `Instance`-like object.
 <br><br>
 
 * [Clone()](#clone): `Instance`
@@ -79,3 +82,36 @@ Methods of a `Instance`.
 > Return children of the `Instance`.
 
 <br/>
+
+## Vortex Studio 0.3.4 method availability
+
+The following matrix records whether each member was exposed as a function on
+the live object. It verifies availability, not every edge case of the method's
+behavior.
+
+| Runtime object | `FindFirstChild` | `FindFirstChildOfClass` | `WaitForChild` | `GetChildren` | `GetDescendants` | `Clone` | `Destroy` | `IsA` |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| [`Part`](./part.md) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| [`Script`](./script.md) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| [`Character`](./character.md) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| [`Workspace`](./workspace.md) | Yes | No | Yes | Yes | No | No | No | No |
+| [`ReplicatedStorage`](./replicated-storage.md) | Yes | No | Yes | Yes | No | No | No | No |
+| [`Players`](./players.md) | No | No | No | No | No | No | No | No |
+| [`Player`](./player.md) | No | No | No | No | No | No | No | No |
+| [`Humanoid`](./humanoid.md) | No | No | No | No | No | No | No | No |
+
+This is why Roblox inheritance alone is not enough to determine the available
+Vortex API. A `Players` service can still provide its class-specific
+`GetPlayers()` method, and a `Humanoid` can provide `IsDead()`, even though the
+tested generic methods above are absent.
+
+## Introspection limitation
+
+Engine-backed members may be provided through metatable lookup. `pairs()` only
+enumerates direct table keys, so it can omit readable properties and other
+supported members. It can also reveal engine-owned keys that are not public
+API. Do not use `pairs()` as a capability check; test the named member and
+consult the concrete class reference.
+
+These observations were made in Vortex Studio 0.3.4 and may change in later
+versions.


### PR DESCRIPTION
## What changed

- Replace the universal Instance-inheritance assumption with a Vortex Studio 0.3.4 availability matrix for eight commonly expected methods across Part, Script, Character, Workspace, ReplicatedStorage, Players, Player, and Humanoid.
- Explain why pairs() is not a complete or safe way to discover engine APIs.
- Record the confirmed missing Character methods and the supported FindFirstChildOfClass alternative.
- Document that an editor-authored Script under a Workspace Part executes and receives that Part through script.Parent.
- Clarify that runtime-created Scripts remain non-executable because Source is not settable.

## Accuracy and scope

Every behavior added here was reproduced in Vortex Studio 0.3.4. The wording distinguishes method presence from complete behavioral verification and avoids treating internal table keys as public API.

This branch is synced with current main, including merged PR #30. The remaining open PRs were checked by filename; none changes these three pages.

## Verification

- git diff --check
- Relative Markdown link validation for all changed pages
- Reviewed the final three-file diff against current main