### PR TITLE
docs: expand InputObject and datatype examples

### DIFF
--- a/content/reference/datatypes/cframe.md
+++ b/content/reference/datatypes/cframe.md
@@ -450,6 +450,25 @@ Methods of a `CFrame`.
 
 <br/>
 
+## Position and rotation example
+
+A CFrame stores position and rotation together. Angles use radians, so
+`math.rad` makes degree values easier to read:
+
+```luau
+local position = CFrame.new(0, 5, 0)
+local quarterTurn = CFrame.Angles(0, math.rad(90), 0)
+local transform = position * quarterTurn
+
+local part = workspace:FindFirstChild("MyPart")
+if part then
+    part.CFrame = transform
+end
+```
+
+Multiplication composes transforms. In this example, the Part is placed five
+studs above the origin and rotated 90 degrees around the Y axis.
+
 ## Operators
 
 The following expressions completed successfully in both `Script` and `LocalScript`:
@@ -474,3 +493,6 @@ fails because the current implementation indexes the missing argument.
 
 The lowercase aliases `components`, `toEulerAnglesXYZ`, and
 `toEulerAnglesYXZ` are also exposed; this reference uses the canonical names.
+
+The position-and-rotation example was revalidated in Vortex Studio 0.3.8. It
+produced position `(0, 5, 0)` and a LookVector of approximately `(-1, 0, 0)`.

--- a/content/reference/datatypes/color3.md
+++ b/content/reference/datatypes/color3.md
@@ -107,8 +107,36 @@ Methods of a `Color3`.
 
 <br/>
 
+## Examples
+
+Use `fromRGB` when working with familiar `0` to `255` color values. Use `new`
+when the components are already normalized from `0` to `1`:
+
+```luau
+local orangeFromRGB = Color3.fromRGB(255, 128, 0)
+local orangeNormalized = Color3.new(1, 128 / 255, 0)
+
+local part = workspace:FindFirstChild("MyPart")
+if part then
+    part.Color = orangeFromRGB
+end
+```
+
+`Lerp` creates a color between two endpoints. An `alpha` of `0` returns the
+starting color, `1` returns the target, and `0.5` returns the midpoint:
+
+```luau
+local red = Color3.fromRGB(255, 0, 0)
+local blue = Color3.fromRGB(0, 0, 255)
+local purple = red:Lerp(blue, 0.5)
+```
+
 ## Testing Notes
 
 The previously listed `Color3.fromHSV` and `Color3.fromHex` constructors were
 removed from this reference because they are not exposed in Vortex Studio
 0.3.4. Runtime availability may change in later releases.
+
+The examples above were revalidated in Vortex Studio 0.3.8.
+`Color3.fromRGB(255, 128, 0)` produced approximately `(1, 0.502, 0)`, and the
+red-to-blue midpoint produced `(0.5, 0, 0.5)`.

--- a/content/reference/datatypes/connection.md
+++ b/content/reference/datatypes/connection.md
@@ -46,6 +46,31 @@ Methods of a `Connection`.
 > Disconnects the callback. Future signal fires no longer invoke it, and
 > `Connected` becomes `false`.
 
+## Example
+
+Keep the returned Connection when the callback should stop later:
+
+```luau
+local part = workspace:FindFirstChild("Baseplate")
+if not part then
+    return
+end
+
+local signal = part.Changed
+local connection = signal:Connect(function(message)
+    print(message)
+end)
+
+signal:Fire("received")
+connection:Disconnect()
+signal:Fire("not received")
+
+print(connection.Connected) -- false
+```
+
+This uses an engine-owned Signal. The standalone `Signal.new` constructor was
+not available in the tested Vortex Studio 0.3.8 server Script.
+
 ## Testing Notes
 
 These observations are from Vortex Studio 0.3.4 and may differ in later
@@ -58,3 +83,7 @@ In both Script and LocalScript, `Connected` began as `true`, a manually fired
 signal delivered its callback once, and `Disconnect()` changed `Connected` to
 `false` and prevented later delivery. The lowercase `disconnect()` alias has
 the same effect.
+
+The engine-owned Signal example was revalidated in a Vortex Studio 0.3.8
+server Script. The callback ran for the first manual fire, `Disconnect()` made
+`Connected` false, and a second fire did not run the callback.

--- a/content/reference/datatypes/enum.md
+++ b/content/reference/datatypes/enum.md
@@ -18,7 +18,7 @@ Methods of an `Enum`.
 <br><br>
 
 * [GetEnumItems()](#getenumitems): `EnumItem[]`
-* [FromName(name: `String`)](#fromnamename-string): `EnumItem`
+* [FromName(name: `String`)](#fromnamename-string): `EnumItem | nil`
 * [FromValue(value: `Number`)](#fromvaluevalue-number): `EnumItem`
 
 </details>
@@ -35,7 +35,7 @@ Methods of an `Enum`.
 
 ### FromName(name: `String`)
 
-> `EnumItem`
+> `EnumItem | nil`
 >
 > Finds an `EnumItem` by name.
 
@@ -48,3 +48,37 @@ Methods of an `Enum`.
 > Finds an `EnumItem` by value.
 
 <br/>
+
+## Examples
+
+Use an enum group to look up a named item:
+
+```luau
+local jumpKey = Enum.KeyCode:FromName("Space")
+
+if jumpKey == Enum.KeyCode.Space then
+    print("Space is the jump key")
+end
+```
+
+An unknown name returns `nil`, so check user-supplied names before using the
+result:
+
+```luau
+local key = Enum.KeyCode:FromName("NotAKey")
+
+if key == nil then
+    print("Unknown key name")
+end
+```
+
+`GetEnumItems()` is useful when building a list of allowed choices:
+
+```luau
+for _, material in ipairs(Enum.Material:GetEnumItems()) do
+    print(material.Name)
+end
+```
+
+In Vortex Studio 0.3.8, `FromName("R")` returned `Enum.KeyCode.R` and an
+unknown name returned `nil`.

--- a/content/reference/datatypes/enumitem.md
+++ b/content/reference/datatypes/enumitem.md
@@ -48,3 +48,23 @@ Properties of an `EnumItem`.
 > A reference to the parent `Enum` of the `EnumItem`.
 
 <br/>
+
+## Example
+
+Enum items are named values. Compare the item itself in game logic, and use
+its properties when displaying or inspecting it:
+
+```luau
+local key = Enum.KeyCode.R
+
+print(key.Name)     -- R
+print(key.Value)    -- 114 in Vortex Studio 0.3.8
+print(key.EnumType) -- Enum.KeyCode
+
+if key == Enum.KeyCode.R then
+    print("The values match")
+end
+```
+
+Avoid depending on a numeric `Value` when an enum item is available. The named
+item is clearer and does not require the number to remain unchanged.

--- a/content/reference/datatypes/input-object.md
+++ b/content/reference/datatypes/input-object.md
@@ -1,5 +1,83 @@
-> `InputObject`
+---
+title: InputObject
+description: Describes one client input delivered by UserInputService.
+---
+
+An `InputObject` is a table describing one client input. Scripts do not
+construct it directly. A client
+[`LocalScript`](../classes/localscript.md) receives it from
+[`UserInputService`](../classes/user-input-service.md) signals such as
+`InputBegan` and `InputEnded`.
+
+The signal callback also receives `gameProcessed`, a Boolean that reports
+whether the engine already handled the input. Gameplay controls commonly
+return early when it is `true`, which prevents typing in chat or using an
+engine control from also triggering the game action.
+
+## Properties
+
+### KeyCode
+
+> [`EnumItem`](./enumitem.md)
 >
-> An object that contains information about a user's input. It can be used to determine what type of input occurred, such as keyboard, mouse, or other supported input devices.
+> The keyboard key associated with the input.
+
+Keyboard input supplies the matching `Enum.KeyCode` item. Mouse buttons use
+`Enum.KeyCode.Unknown`, so use `UserInputType` to distinguish mouse buttons.
+
+### UserInputType
+
+> [`EnumItem`](./enumitem.md)
 >
-> `InputObject` values can provide information about the input state, position, and other details related to the input event.
+> The device action that produced the input.
+
+Examples include `Enum.UserInputType.Keyboard`, `MouseButton1`, and
+`MouseButton2`.
+
+### Position
+
+> [`Vector3`](./vector3.md)
+>
+> Positional data supplied with the input.
+
+### Delta
+
+> [`Vector3`](./vector3.md)
+>
+> The change in position supplied with the input.
+
+## Keyboard and mouse example
+
+```luau
+local UserInputService = game:GetService("UserInputService")
+
+UserInputService.InputBegan:Connect(function(input, gameProcessed)
+    if gameProcessed then
+        return
+    end
+
+    if input.UserInputType == Enum.UserInputType.Keyboard
+        and input.KeyCode == Enum.KeyCode.E then
+        print("E was pressed")
+    elseif input.UserInputType == Enum.UserInputType.MouseButton1 then
+        print("The left mouse button was pressed")
+    end
+end)
+```
+
+Compare enum items directly. Do not compare `KeyCode` or `UserInputType` with
+strings such as `"E"` or `"MouseButton1"`.
+
+## Vortex Studio 0.3.8 notes
+
+`InputBegan` delivered InputObjects as tables in a LocalScript. Keyboard input
+reported `Enum.UserInputType.Keyboard` and its actual `KeyCode`. Left and right
+mouse buttons reported `MouseButton1` and `MouseButton2`, with
+`Enum.KeyCode.Unknown`.
+
+`Position` and `Delta` were exposed as `Vector3` values, but both remained
+`(0, 0, 0)` for the tested keyboard and mouse-button inputs. Do not treat them
+as confirmed mouse-cursor coordinates in this release.
+
+`UserInputState`, `Changed`, and `IsModifierKeyDown` read as `nil`. Touch and
+gamepad InputObjects were not tested.

--- a/content/reference/datatypes/signal.md
+++ b/content/reference/datatypes/signal.md
@@ -33,14 +33,16 @@ Written by TheJustDare on August 30th, 2026
 Connects the given function and creates a new [Connection](./connection.md).
 
 ```lua
-local part = workspace.Part
-part:SetAttribute("Points", 5)
+local part = workspace:FindFirstChild("Baseplate")
+if not part then
+    return
+end
 
-part:GetAttributeChangedSignal("Points"):Connect(function()
-    local newPoints = part:GetAttribute("Points")
-
-    print(newPoints) -- Returns 5
+local connection = part.Changed:Connect(function(message)
+    print(message)
 end)
+
+part.Changed:Fire("changed")
 ```
 
 <br>
@@ -50,7 +52,12 @@ end)
 Synchronously invokes connected callbacks with the supplied arguments.
 
 ```lua
-local signal = Signal.new("Example")
+local part = workspace:FindFirstChild("Baseplate")
+if not part then
+    return
+end
+
+local signal = part.Changed
 signal:Connect(function(message)
     print(message)
 end)
@@ -65,16 +72,17 @@ Connects the given function and creates a new [Connection](./connection.md). \
 `Once` will run the function only **once**, unlike the other methods.
 
 ```lua
-local part = workspace.Part
-part.Name = "Block"
+local part = workspace:FindFirstChild("Baseplate")
+if not part then
+    return
+end
 
-part:GetPropertyChangedSignal("Name"):Once(function()
-    print("The part's name has been changed!")
+part.Changed:Once(function(message)
+    print(message)
 end)
 
-task.wait(1)
-
-part.Name = "Cube"
+part.Changed:Fire("first")
+part.Changed:Fire("second") -- the callback does not run again
 ```
 
 ### Wait()
@@ -83,7 +91,9 @@ Yields the current thread until the `Signal` fires. `Wait()` returns arguments p
 
 ### new()
 
-`Signal.new(name: String)` creates a standalone signal that can be connected to and fired.
+`Signal.new` was available in the earlier 0.3.4 tests, but the global `Signal`
+was `nil` in a Vortex Studio 0.3.8 server Script. Use an engine-owned signal,
+such as `Part.Changed`, in the current release.
 
 ## Vortex Studio 0.3.4 notes
 
@@ -102,3 +112,8 @@ deliver callbacks in 0.3.4.
 In 0.3.4, lowercase `connect` and `fire` work on `Part.Changed`, and
 `Signal.new` creates a standalone signal whose `Connect` callback receives a
 manually fired argument. This was confirmed in both Script and LocalScript.
+
+In Vortex Studio 0.3.8, an engine-owned `Part.Changed` signal still exposed
+`Connect`, `Fire`, `Once`, and `Wait`. A manual `Fire("yes")` reached a connected
+callback once; after `Disconnect()`, a second fire did not reach it. The global
+`Signal` constructor was `nil` in the tested server Script.


### PR DESCRIPTION
## What changed
Replace the InputObject placeholder with a Vortex Studio 0.3.8-verified reference for KeyCode, UserInputType, Position, Delta, gameProcessed, and current unavailable fields.
- Add copyable beginner examples for keyboard and mouse input, Enum and EnumItem, Color3, CFrame, Connection, and Signal.
- Replace Signal examples that no longer run in 0.3.8: Signal.new is nil in a tested server Script, while engine-owned Part. Changed still supports Connect, Fire, Once, and Wait.
- Keep Vector3, Tween, and TweenInfo out of this PR because PR #42 already changes them.

## Verification
- Ran keyboard, left-mouse, and right-mouse InputObject probes in Vortex Studio 0.3.8.
- Ran the Enum, Color3, CFrame, Signal, and Connection examples in Vortex Studio 0.3.8.
- Ran git diff checks plus frontmatter and code-fence validation for every changed page.
- Confirmed no open PR modifies these seven files.